### PR TITLE
編集時にindexPathの代わりに選択されたtweetを渡すようにした

### DIFF
--- a/MyTwitterApp.xcodeproj/project.pbxproj
+++ b/MyTwitterApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -172,7 +172,7 @@
 				};
 			};
 			buildConfigurationList = 238F3C59293B6B8300C3B945 /* Build configuration list for PBXProject "MyTwitterApp" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/MyTwitterApp/Controller/MainViewController.swift
+++ b/MyTwitterApp/Controller/MainViewController.swift
@@ -97,7 +97,8 @@ extension MainViewController: UITableViewDelegate{
         let tweetViewController = storyboard.instantiateViewController(identifier: "TweetViewController") as! TweetViewController
         let tweetData = tweetList[indexPath.row]
         tweetViewController.delegate = self
-        tweetViewController.tweetIndexPath = indexPath.row
+
+        tweetViewController.tweet = tweetList[indexPath.row]
         tweetViewController.configure(deta: tweetData)
         present(tweetViewController,animated: true)
     }

--- a/MyTwitterApp/Controller/TweetViewController.swift
+++ b/MyTwitterApp/Controller/TweetViewController.swift
@@ -17,7 +17,8 @@ class TweetViewController: UIViewController{
     
     var maxLength: Int = 140
     var nowLength: Int = 0
-    var tweetIndexPath: Optional<Int> = nil
+
+    var tweet: TweetModel?
     
     @IBOutlet weak var tweetLabel: UITextField!
     @IBOutlet weak var nameLabel: UITextField!
@@ -70,35 +71,36 @@ class TweetViewController: UIViewController{
     }
     
     @objc func tapAddButton(){
-        if maxLength - nowLength >= 0 {
-            if tweetIndexPath != nil{
-                try! realm.write{
-                    TweetList[Int(tweetIndexPath!)].name = nameLabel.text!
-                    TweetList[Int(tweetIndexPath!)].tweet = tweetLabel.text!
-                    TweetList[Int(tweetIndexPath!)].date = Date()
-                }
-            }else{
-                
-                try! realm.write{
-                    tweetData.name = nameLabel.text!
-                    tweetData.tweet = tweetLabel.text!
-                    tweetData.date = Date()
-                    realm.add(tweetData)
-                }
-            }
-            delegate?.updateTweet()
-            dismiss(animated: true)
-        } else {
+        if maxLength < nowLength {
             let alertController:UIAlertController = UIAlertController(title: "文字数が140文字を超えています", message: "文字数を減らして再度入力してください", preferredStyle: .alert)
             let cancelAction = UIAlertAction(title:"やり直す",style: .cancel){action in
                 return
             }
             alertController.addAction(cancelAction)
             present(alertController, animated: true)
-            
+            return
         }
+
+        if let tweet = tweet { // 更新
+            try! realm.write {
+                tweet.name = nameLabel.text!
+                tweet.tweet = tweetLabel.text!
+                tweet.date = Date()
+            }
+        } else { // 追加
+            let tweet = TweetModel()
+            tweet.name = nameLabel.text!
+            tweet.tweet = tweetLabel.text!
+            tweet.date = Date()
+
+            try! realm.write {
+                realm.add(tweet)
+            }
+        }
+
+        delegate?.updateTweet()
+        dismiss(animated: true)
     }
-    
 }
 
 extension TweetViewController: UITextFieldDelegate{


### PR DESCRIPTION
## 対応内容
- TweetViewControllerのindexPathをtweetに変更
- セルを選択してツイート画面に遷移するとき、indexPathの代わりに選択されたtweetを渡すようにした

## 動作
https://user-images.githubusercontent.com/82485612/206848985-4af72336-2909-4d0f-ad73-fe605548815b.mov

